### PR TITLE
NMS-610 add 'online:bool' variable.

### DIFF
--- a/run.py
+++ b/run.py
@@ -10,4 +10,4 @@ if __name__=="__main__":
     parser.add_argument('--yaml_path', type=str, required=True, help='yaml file path')
     args = parser.parse_args()
     dir_path, dataset_type, yaml_path = args.dir, args.format.lower(), args.yaml_path
-    validate(dir_path, dataset_type, yaml_path)
+    validate(dir_path, dataset_type, yaml_path, online=False)

--- a/src/utils.py
+++ b/src/utils.py
@@ -311,7 +311,7 @@ def write_error_txt(errors:List[str]):
     f.close()
 
     
-def validate(root_path: str, data_format:str, yaml_path:str, delete=False):
+def validate(root_path: str, data_format:str, yaml_path:str, delete=False, online=True):
     logger.info("Start dataset validation.")
     errors = []
     dir_path = Path(root_path)
@@ -333,6 +333,9 @@ def validate(root_path: str, data_format:str, yaml_path:str, delete=False):
         logger.info("Validation completed! Now try your dataset on NetsPresso!")
     else:
         write_error_txt(errors)
-        logger.info("Validation error, please check 'validation_result.txt'.")
+        if online:
+            logger.info("Validation error, please visit 'https://github.com/Nota-NetsPresso/NetsPresso-ModelSearch-Dataset-Validator' and validate dataset.")
+        else:
+            logger.info("Validation error, please check 'validation_result.txt'.")
     if delete:
         delete_dirs(dir_path)


### PR DESCRIPTION
https://nota-dev.atlassian.net/browse/NMS-610

웹페이지에서 dataset upload 를 한 경우와, 로컬에서 validation 을 한 경우 출력되는 문장을 구분할 필요가 있음.
따라서 공개 validation repo 를 일부 수정함.

### 변경사항

validation 을 통과 못 하는 경우 
프론트에서는 아래 문장 출력
```
Validation error, please visit 'https://github.com/Nota-NetsPresso/NetsPresso-ModelSearch-Dataset-Validator' and validate dataset.
```

공개 validator 를 받아서 local 에서 실행한 경우 아래 문장 출력
```
Validation error, please check 'validation_result.txt'.
```

이를 위해 src/utils.py → validate 함수에 online:bool 변수 추가
```
validate(root_path: str, data_format:str, yaml_path:str, delete=False, online=True)
```

