### PR TITLE
NMS-792 change logger.info to logger debug and print

### DIFF
--- a/run.py
+++ b/run.py
@@ -15,4 +15,4 @@ if __name__ == "__main__":
         args.yaml_path,
         args.fix,
     )
-    validate(dir_path, dataset_type, yaml_path, online=False, fix=fix)
+    validate(dir_path, dataset_type, yaml_path, online=False, fix=fix, local=True)

--- a/src/coco.py
+++ b/src/coco.py
@@ -2,11 +2,10 @@ from typing import Dict, List
 from pathlib import Path
 import sys
 
-import yaml
 from loguru import logger
 sys.path.append("app/core/validator")
 from src.utils import (json_load, get_dir_list,
-                       get_img_file_types, get_target_dirs)
+                       get_img_file_types, get_target_dirs, log_n_print)
 
 
 def validate_coco_bbox(
@@ -244,13 +243,13 @@ def validate(
     img_list:None,
     yaml_label:None,
     errors:List[str],
-    fix:bool=False # not used but be here for other dataset type
+    fix:bool=False, # not used but be here for other dataset type
 ):
     """
     'img_list' and 'yaml_label' are not used in this function, but written for dynamic importing in src.utils.py
     """
     errors = validate_json_exist(dir_path, errors)
-    logger.info("[Validate: 5/6]:  Validation finished for existing json files in the correct position.")
+    log_n_print("[Validate: 5/6]:  Validation finished for existing json files in the correct position.")
     errors = validate_label_files(label_list, num_classes, errors)
-    logger.info("[Validate: 6/6]: Validation finished for label files.")
+    log_n_print("[Validate: 6/6]: Validation finished for label files.")
     return errors

--- a/src/utils.py
+++ b/src/utils.py
@@ -323,6 +323,13 @@ def write_error_txt(errors: List[str]):
     f.close()
 
 
+def log_n_print(message:str):
+    if not LOCAL:
+        logger.debug(message)
+    else:
+        print(message)
+
+
 def validate(
     root_path: str,
     data_format: str,
@@ -330,27 +337,28 @@ def validate(
     delete=False,
     online=True,
     fix=False,
+    local=False # True for local run, False for BE run.
 ):
-    logger.info("Start dataset validation.")
-    logger.info("=========================")
-    logger.info(f"data path: {root_path}")
-    logger.info(f"data format: {data_format}")
-    logger.info(f"yaml path: {yaml_path}")
-    logger.info(f"autofix: {fix}")
-    logger.info("=========================")
+    global LOCAL
+    LOCAL = local
+    log_n_print("Start dataset validation.")
+    log_n_print("=========================")
+    log_n_print(f"data path: {root_path}")
+    log_n_print(f"data format: {data_format}")
+    log_n_print(f"yaml path: {yaml_path}")
+    log_n_print(f"autofix: {fix}")
+    log_n_print("=========================")
     errors = []
     dir_path = Path(root_path)
     dir_paths, errors = validate_first_dirs(dir_path, errors)
-    logger.info(
-        "[Validate: 1/6]: Done validation dir structure ['train', 'val', 'test']."
-    )
+    log_n_print("[Validate: 1/6]: Done validation dir structure ['train', 'val', 'test'].")
     errors = validate_second_dirs(dir_paths, errors)
-    logger.info("[Validate: 2/6]: Done validation dir structure ['images', 'labels'].")
+    log_n_print("[Validate: 2/6]: Done validation dir structure ['images', 'labels'].")
     validate_dataset_type(root_path, data_format)
-    logger.info("[Validate: 3/6]: Done validation, user select correct data type.")
+    log_n_print("[Validate: 3/6]: Done validation, user select correct data type.")
     img_list, label_list = get_file_lists(dir_paths)
     yaml_label, errors, num_classes = validate_data_yaml(yaml_path, errors)
-    logger.info(f"[Validate: 4/6]: Done validation for {yaml_path} file.")
+    log_n_print(f"[Validate: 4/6]: Done validation for {yaml_path} file.")
     _validate = getattr(
         importlib.import_module(f"src.{data_format.lower()}"),
         "validate",
@@ -359,14 +367,14 @@ def validate(
         dir_path, num_classes, label_list, img_list, yaml_label, errors, fix
     )
     if len(errors) == 0:
-        logger.info("Validation completed! Now try your dataset on NetsPresso!")
+        log_n_print("Validation completed! Now try your dataset on NetsPresso!")
     else:
         write_error_txt(errors)
         if online:
-            logger.info(
+            log_n_print(
                 "Validation error, please visit 'https://github.com/Nota-NetsPresso/NetsPresso-ModelSearch-Dataset-Validator' and validate dataset."
-            )
+                )
         else:
-            logger.info("Validation error, please check 'validation_result.txt'.")
+            log_n_print("Validation error, please check 'validation_result.txt'.")
     if delete:
         delete_dirs(dir_path)

--- a/src/voc.py
+++ b/src/voc.py
@@ -1,11 +1,10 @@
 from typing import Dict, List
 import sys
 
-from loguru import logger
 sys.path.append("app/core/validator")
 from src.utils import (get_bbox_from_xml_obj, get_image_info_xml, 
                        get_label2id, validate_image_files_exist,
-                       xml_load)
+                       xml_load, log_n_print)
 
 
 def validate_label_files(
@@ -124,7 +123,7 @@ def validate(
         return errors
     errors = validate_yaml_names(yaml_label, label2id, num_classes, errors)
     errors = validate_image_files_exist(img_list, label_list, "xml", errors)
-    logger.info("[Validate: 5/6]: Validation finished for existing image files in the correct position.")
+    log_n_print("[Validate: 5/6]: Validation finished for existing image files in the correct position.")
     errors = validate_label_files(img_list, label_list, num_classes, label2id, errors)
-    logger.info("[Validate: 6/6]: Validation finished for label files.")
+    log_n_print("[Validate: 6/6]: Validation finished for label files.")
     return errors

--- a/src/yolo.py
+++ b/src/yolo.py
@@ -1,12 +1,8 @@
 from typing import Dict, List
 import sys
 
-import yaml
-from loguru import logger
-
 sys.path.append("app/core/validator")
-from src.utils import validate_image_files_exist
-
+from src.utils import validate_image_files_exist, log_n_print
 
 def validate_label_files(
     label_list: List[str], num_classes: int, errors: List[str], fix: bool = False
@@ -103,9 +99,7 @@ def validate(
     fix: bool=False,
 ):
     errors = validate_image_files_exist(img_list, label_list, "txt", errors)
-    logger.info(
-        "[Validate: 5/6]: Validation finished for existing image files in the correct position."
-    )
+    log_n_print("[Validate: 5/6]: Validation finished for existing image files in the correct position.")
     errors = validate_label_files(label_list, num_classes, errors, fix)
-    logger.info("[Validate: 6/6]: Validation finished for label files.")
+    log_n_print("[Validate: 6/6]: Validation finished for label files.")
     return errors


### PR DESCRIPTION
https://nota-dev.atlassian.net/browse/NMS-792

log_n_print 함수를 추가하여 디버깅을 위한 log, 유저 터미널 출력을 위한 print 를 같이 관리함.
유저 화면에서 logger 와 print 가 동시 출력되지 않도록 글로벌 변수 LOCAL 에 따라서 logger 출력 결과가 결정됨.
엔트리포인트인 run.py 에서는 기본값을 True 로 하여 유저 터미널에 print 만 출력,
LOCAL 자체의 기본값은 False 로 하여 BE 에서는 별도의 수정이 필요 없도록 작업하였음
```
def log_n_print(message:str):
    if not LOCAL:
        logger.debug(message)
    print(message)
```